### PR TITLE
Make tools dir order-only in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install-tools: $(TOOLS_BIN_NAMES)
 $(TOOLS_BIN_DIR):
 	mkdir -p $@
 
-$(TOOLS_BIN_NAMES): $(TOOLS_MOD_DIR)/go.mod $(TOOLS_BIN_DIR)
+$(TOOLS_BIN_NAMES): $(TOOLS_MOD_DIR)/go.mod | $(TOOLS_BIN_DIR)
 	cd $(TOOLS_MOD_DIR) && go build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))
 
 $(BIN): .goreleaser.yaml $(GORELEASER)


### PR DESCRIPTION
The timestamp on the directory is updated when a file is added which means when the last tool is installed the directory timestamp is updated to be later than when earlier tools are installed, causing them to be reinstalled in subsequent build stages. Since it doesn't matter when the `.tools/` dir is created and updating it doesn't affect the build, make it an order-only dependency.