### PR TITLE
Remove otelcol_version from builder manifest

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,6 @@ dist:
   module: github.com/Dynatrace/dynatrace-otel-collector
   name: otelcol-dynatrace
   description: Dynatrace OpenTelemetry Collector Distribution
-  otelcol_version: 0.82.0
   output_path: ./build
   version: 0.0.1-alpha
 


### PR DESCRIPTION
We want the Collector core and builder versions to be in sync. By default the builder version is used for the Collector core version.