### PR TITLE
Move Snyk scanning to main CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build and Test
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -43,14 +43,9 @@ jobs:
       - name: Verify
         run: make test
 
-  scan:
-    name: Scan
-    runs-on: ubuntu-22.04
-    needs: build
-    if: github.ref == 'refs/heads/main'
-    steps:
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/golang@master
+        if: github.ref == 'refs/heads/main'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:


### PR DESCRIPTION
This removes the need to pass the `build` directory between jobs.