### PR TITLE
Bump Collector manifest version to v0.0.2-alpha

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -3,7 +3,7 @@ dist:
   name: dynatrace-otel-collector
   description: Dynatrace OpenTelemetry Collector Distribution
   output_path: ./build
-  version: 0.0.1-alpha
+  version: 0.0.2-alpha
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.85.0


### PR DESCRIPTION
This prepares us for the next release.