### PR TITLE
Update healthcheck example for multiple targets

### DIFF
--- a/config_examples/healthcheck.yaml
+++ b/config_examples/healthcheck.yaml
@@ -1,10 +1,11 @@
 receivers:
   httpcheck/eec:
-    endpoint: ${env:heartbeat_url}/${env:heartbeat_id}
-    method: POST
+    targets:
+      - endpoint: ${env:heartbeat_url}/${env:heartbeat_id}
+        method: POST
+        headers:
+          Authorization: "Api-Token ${env:token}"
     collection_interval: 10s
-    headers:
-      Authorization: "Api-Token ${env:token}"
     metrics:
       httpcheck.duration:
         enabled: false


### PR DESCRIPTION
A change in the httpcheck receiver broke our example configuration. It is now possible to specify multiple check targets. As a result, they need to be specified in list format.