### PR TITLE
Remove the memory ballast extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ guide](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/
 
 ### Extensions
 
-* [ballastextension](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/ballastextension)
 * [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension)
 * [zpagesextension](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/zpagesextension)
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -22,7 +22,6 @@ exporters:
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.91.0
-  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.91.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.91.0
 
 processors:


### PR DESCRIPTION
The extension is being deprecated in favor of using the `GOMEMLIMIT` environment variable.