### PR TITLE
docs: fix link in examples README

### DIFF
--- a/config_examples/README.md
+++ b/config_examples/README.md
@@ -5,7 +5,7 @@ Here you can find a collection of example Collector configurations.
 ## Samples
 
 - [Drop](drop.yaml)
-- [Effective](effective.yaml.yaml)
+- [Effective](effective.yaml)
 - [Health check](healthcheck.yaml)
 - [Jaeger Receiver](jaeger.yaml)
 - [Pipeline](pipeline.yaml)


### PR DESCRIPTION
Fixes a link in `config_examples/README.md` that linked `effective.yaml.yaml` instead of `effective.yaml`.