### PR TITLE
Remove the HTTP check receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ and the Collector's [troubleshooting guide].
 * [filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver)
 * [fluentforwardreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/fluentforwardreceiver)
 * [hostmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver)
-* [httpcheckreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver)
 * [jaegereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver)
 * [otlpreceiver](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver)
 * [prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,7 +13,6 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.96.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.96.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.96.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver v0.96.0
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.96.0

--- a/testbed/testdata/config-allcomponents.yaml
+++ b/testbed/testdata/config-allcomponents.yaml
@@ -31,17 +31,6 @@ receivers:
     tcp:
       listen_address: "0.0.0.0:54526"
     protocol: rfc5424
-  httpcheck:
-    targets:
-      - endpoint: http://endpoint:80
-        method: GET
-      - endpoint: http://localhost:8080/health
-        method: GET
-      - endpoint: http://localhost:8081/health
-        method: POST
-        headers:
-          test-header: "test-value"
-    collection_interval: 10s
   otlp:
     protocols:
       grpc:


### PR DESCRIPTION
The component is currently in development and doesn't fit any of our use-cases.