### PR TITLE
Include `timetzdata` build flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ builds:
       - -w
     flags:
       - -trimpath
+      - -tags=timetzdata
     goos:
       - linux
       - windows


### PR DESCRIPTION
Addresses issue where the collector fails to locate timezones when using the Syslog receiver