### PR TITLE
hotfix Include `timetzdata` build flag 

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ builds:
       - -w
     flags:
       - -trimpath
+      - -tags=timetzdata
     goos:
       - linux
       - windows

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -3,7 +3,7 @@ dist:
   name: dynatrace-otel-collector
   description: Dynatrace distribution of the OpenTelemetry Collector
   output_path: ./build
-  version: 0.3.0
+  version: 0.3.1
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.0


### PR DESCRIPTION
Followup from #166, creating a hotfix on the already released v.0.3.0 version.