### PR TITLE
Allow repo content writing on release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
We need write access for things like creating a release.

https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release