### PR TITLE
Prepare v0.6.0 changelog

### DIFF
--- a/.chloggen/summary.tmpl
+++ b/.chloggen/summary.tmpl
@@ -21,9 +21,9 @@ https://github.com/open-telemetry/opentelemetry-collector/releases/tag/vXX.YY.ZZ
 https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/vXX.YY.ZZ
 
 <details>
-<summary>Highlights from the above changelog</summary>
-
-- 
+<summary>Highlights from the upstream Collector changelog</summary>
+</br>
+-
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v
 <summary>Highlights from the upstream Collector changelog</summary>
 </br>
 
-🛑 Breaking changes 🛑
+### 🛑 Breaking changes 🛑
 
 - `filelog, journald, tcp, udp, syslog, windowseventlog receivers`: The internal logger has been changed from zap.SugaredLogger to zap.Logger. ([#32177](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32177))
 This should not have any meaningful impact on most users but the logging format for some logs may have changed.
 
-💡 Enhancements 💡
+### 💡 Enhancements 💡
 
 - `filelogreceiver`: Add container operator parser ([#31959](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31959))
 - `resourcedetectionprocessor`: Support GCP Bare Metal Solution in resource detection processor. ([#32985](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32985))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,31 @@
 # Changelog
 
 <!-- next version -->
+
+## v0.6.1
+
+This release includes version 0.101.0 of the upstream Collector components.
+
+The individual changelogs can be found here:
+
+v0.101.0:
+https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.101.0
+https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.101.0
+
+<details>
+
+<summary>Highlights from the upstream Collector changelog</summary>
+</br>
+
+🛑 Breaking changes 🛑
+
+- `filelog, journald, tcp, udp, syslog, windowseventlog receivers`: The internal logger has been changed from zap.SugaredLogger to zap.Logger. ([#32177](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32177))
+This should not have any meaningful impact on most users but the logging format for some logs may have changed.
+
+💡 Enhancements 💡
+
+- `filelogreceiver`: Add container operator parser ([#31959](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31959))
+- `resourcedetectionprocessor`: Support GCP Bare Metal Solution in resource detection processor. ([#32985](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32985))
+- `processor/transform`: Allow common where clause ([#27830](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27830))
+
+</details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 <!-- next version -->
 
-## v0.6.1
+## v0.6.0
 
 This release includes version 0.101.0 of the upstream Collector components.
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -3,7 +3,7 @@ dist:
   name: dynatrace-otel-collector
   description: Dynatrace distribution of the OpenTelemetry Collector
   output_path: ./build
-  version: 0.5.0
+  version: 0.6.0
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.101.0


### PR DESCRIPTION
Since this is the first release with the new changelog process, we will have to manually add the things we did as there's no changelog entry files. We can grab those from the automated release notes GH generates once we create the tag and release. 