### PR TITLE
Manually add items from the 0.6.0 release to changelog

### DIFF
--- a/.chloggen/summary.tmpl
+++ b/.chloggen/summary.tmpl
@@ -14,11 +14,11 @@
 
 This release includes version XX.YY.ZZ of the upstream Collector components.
 
-The individual changelogs can be found here:
+The individual upstream Collector changelogs can be found here:
 
 vXX.YY.ZZ:
-https://github.com/open-telemetry/opentelemetry-collector/releases/tag/vXX.YY.ZZ
-https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/vXX.YY.ZZ
+- https://github.com/open-telemetry/opentelemetry-collector/releases/tag/vXX.YY.ZZ
+- https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/vXX.YY.ZZ
 
 <details>
 <summary>Highlights from the upstream Collector changelog</summary>
@@ -29,7 +29,7 @@ https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v
 
 {{- if .BreakingChanges }}
 
-### Breaking changes
+### 🛑 Breaking changes 🛑
 
 {{- range $i, $change := .BreakingChanges }}
 {{- if eq $i 0}}
@@ -40,7 +40,7 @@ https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v
 
 {{- if .Deprecations }}
 
-### Deprecations
+### 🚩 Deprecations 🚩
 
 {{- range $i, $change := .Deprecations }}
 {{- if eq $i 0}}
@@ -51,7 +51,7 @@ https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v
 
 {{- if .NewComponents }}
 
-### New components
+### 🚀 New components 🚀
 
 {{- range $i, $change := .NewComponents }}
 {{- if eq $i 0}}
@@ -62,7 +62,7 @@ https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v
 
 {{- if .Enhancements }}
 
-### Enhancements
+### 💡 Enhancements 💡
 
 {{- range $i, $change := .Enhancements }}
 {{- if eq $i 0}}
@@ -73,7 +73,7 @@ https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v
 
 {{- if .BugFixes }}
 
-### Bug fixes
+### 🧰 Bug fixes 🧰
 
 {{- range $i, $change := .BugFixes }}
 {{- if eq $i 0}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@
 
 This release includes version 0.101.0 of the upstream Collector components.
 
-The individual changelogs can be found here:
+The individual upstream Collector changelogs can be found here:
 
 v0.101.0:
-https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.101.0
-https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.101.0
+- https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.101.0
+- https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.101.0
 
 <details>
 
@@ -31,3 +31,8 @@ This should not have any meaningful impact on most users but the logging format 
 - `processor/transform`: Allow common where clause ([#27830](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27830))
 
 </details>
+
+### 💡 Enhancements 💡
+
+- Add section to list which container registries are available to pull images from ([#188](https://github.com/Dynatrace/dynatrace-otel-collector/pull/188))
+- Use chloggen to generate changelog entries ([#191](https://github.com/Dynatrace/dynatrace-otel-collector/pull/191))


### PR DESCRIPTION
Hand-picked items from the auto-generated release notes to the CHANGELOG.md. From now one, this will not be needed as we will be using the changelog tooling. 

I also modified the changelog template a bit, to match the upstream collector "style".