### PR TITLE
test(examples/syslog): add test and example for syslog

### DIFF
--- a/.chloggen/feat_int-test-syslog.yaml
+++ b/.chloggen/feat_int-test-syslog.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'examples'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added an example for using the syslog receiver, as well as integration tests for the added example.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [136]

--- a/config_examples/README.md
+++ b/config_examples/README.md
@@ -13,6 +13,7 @@ Dynatrace distribution of the OpenTelemetry Collector.
 - [Tail sampling](tail_sampling.yaml)
 - [Splitting `sum`/`count` from Histogram metrics](split_histogram.yaml)
 - [Deriving request metrics from pre-sampled traces](spanmetrics.yaml)
+- [Syslog Receiver](syslog.yaml)
 
 ## Sending data to Dynatrace
 

--- a/config_examples/syslog.yaml
+++ b/config_examples/syslog.yaml
@@ -1,0 +1,41 @@
+receivers:
+  syslog/f5:
+    tcp:
+      listen_address: "0.0.0.0:54526"
+    protocol: rfc5424
+    operators:
+      - type: add
+        field: attributes.log.source
+        value: syslog
+      - type: add
+        field: attributes.dt.ip_addresses
+        value: "1xx.xx.xx.xx1"
+      - type: add
+        field: attributes.instance.name
+        value: "ip-1xx-xx-x-xx9.ec2.internal"
+      - type: add
+        field: attributes.device.type
+        value: "f5bigip"
+  syslog/host:
+    tcp:
+      listen_address: "0.0.0.0:54527"
+    protocol: rfc5424
+    operators:
+      - type: add
+        field: attributes.log.source
+        value: syslog
+      - type: add
+        field: attributes.device.type
+        value: "ubuntu-syslog"
+
+exporters:
+  otlphttp:
+    endpoint: ${env:DT_ENDPOINT}
+    headers:
+      Authorization: "Api-Token ${env:API_TOKEN}"
+
+service:
+  pipelines:
+    logs:
+      receivers: [syslog/f5, syslog/host]
+      exporters: [otlphttp]

--- a/internal/testbed/integration/syslog_logs_validation.go
+++ b/internal/testbed/integration/syslog_logs_validation.go
@@ -1,0 +1,114 @@
+package integration
+
+import (
+	"fmt"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
+	"github.com/stretchr/testify/assert"
+)
+
+var _ testbed.TestCaseValidator = &SyslogSampleConfigsValidator{}
+
+type SyslogSampleConfigsValidator struct {
+	expectedLogs plog.Logs
+	t            *testing.T
+}
+
+// NewSyslogSampleConfigValidator ensures expected logs are present in the output.
+func NewSyslogSampleConfigValidator(t *testing.T, expectedLogs plog.Logs) *SyslogSampleConfigsValidator {
+	return &SyslogSampleConfigsValidator{
+		expectedLogs: expectedLogs,
+		t:            t,
+	}
+}
+
+func (v *SyslogSampleConfigsValidator) Validate(tc *testbed.TestCase) {
+	actualLogs := 0
+	for _, td := range tc.MockBackend.ReceivedLogs {
+		actualLogs += td.LogRecordCount()
+	}
+
+	assert.EqualValues(v.t, v.expectedLogs.LogRecordCount(), actualLogs, "Expected %d logs, received %d.", v.expectedLogs.LogRecordCount(), actualLogs)
+	assertExpectedLogsAreInReceived(v.t, []plog.Logs{v.expectedLogs}, tc.MockBackend.ReceivedLogs)
+}
+
+func (v *SyslogSampleConfigsValidator) RecordResults(tc *testbed.TestCase) {
+}
+
+func assertExpectedLogsAreInReceived(t *testing.T, expected, actual []plog.Logs) {
+	expectedMap := make(map[string]plog.LogRecord)
+	populateLogsMap(expectedMap, expected)
+
+	for _, td := range actual {
+		resourceLogs := td.ResourceLogs()
+		for i := 0; i < resourceLogs.Len(); i++ {
+			scopeLogs := resourceLogs.At(i).ScopeLogs()
+			for j := 0; j < scopeLogs.Len(); j++ {
+				logRecords := scopeLogs.At(j).LogRecords()
+				for k := 0; k < logRecords.Len(); k++ {
+					actualLogRecord := logRecords.At(k)
+					hasEntry := assert.Contains(t,
+						expectedMap,
+						actualLogRecord.Body().AsString(),
+						fmt.Sprintf("Actual log with body : %q not found among expected logRecords", actualLogRecord.Body().AsString()))
+
+					// avoid panic due to expectedLogRecord being nil
+					if !hasEntry {
+						return
+					}
+
+					expectedLogRecord := expectedMap[actualLogRecord.Body().AsString()]
+					assert.Equal(t, expectedLogRecord.Timestamp().String(), actualLogRecord.Timestamp().String())
+					assertMap(t, expectedLogRecord.Attributes(), actualLogRecord.Attributes())
+					assert.Equal(t, expectedLogRecord.SpanID(), actualLogRecord.SpanID())
+					assert.Equal(t, expectedLogRecord.TraceID(), actualLogRecord.TraceID())
+					assert.Equal(t, expectedLogRecord.Body(), actualLogRecord.Body())
+					// the syslog receiver will override the ObservedTimestamp with the current timestamp on the collector, so we test if the actual timestamp has been after the expected one.
+					assert.LessOrEqual(t, expectedLogRecord.ObservedTimestamp().AsTime(), actualLogRecord.ObservedTimestamp().AsTime())
+				}
+			}
+		}
+	}
+}
+
+// populateLogsMap populates a map with the body as the key and a LogRecord as the value for easier log record matching
+func populateLogsMap(logsMap map[string]plog.LogRecord, tds []plog.Logs) {
+	for _, td := range tds {
+		resourceLogs := td.ResourceLogs()
+		for i := 0; i < resourceLogs.Len(); i++ {
+			scopeLogs := resourceLogs.At(i).ScopeLogs()
+			for j := 0; j < scopeLogs.Len(); j++ {
+				logs := scopeLogs.At(j).LogRecords()
+				for k := 0; k < logs.Len(); k++ {
+					log := logs.At(k)
+					key := log.Body().AsString()
+					logsMap[key] = log
+				}
+			}
+		}
+	}
+}
+
+func assertMap(t *testing.T, expected pcommon.Map, actual pcommon.Map) {
+	assert.Equal(t, expected.Len(), actual.Len())
+	expected.Range(func(expectedKey string, expectedValue pcommon.Value) bool {
+		actualValue, exists := actual.Get(expectedKey)
+		assert.True(t, exists, "Expected attribute %s, but no attribute was present", expectedKey)
+		assertValue(t, expectedValue, actualValue)
+		return true
+	})
+}
+
+func assertValue(t *testing.T, expected pcommon.Value, actual pcommon.Value) {
+	assert.Equal(t, expected.Type(), actual.Type())
+	switch expected.Type() {
+	case pcommon.ValueTypeMap:
+		assertMap(t, expected.Map(), actual.Map())
+		break
+	default:
+		assert.Equal(t, expected, actual)
+	}
+}

--- a/internal/testbed/integration/testutils.go
+++ b/internal/testbed/integration/testutils.go
@@ -19,6 +19,14 @@ func replaceJaegerGrpcReceiverPort(cfg string, receiverPort int) string {
 	return strings.Replace(cfg, "14250", strconv.Itoa(receiverPort), 1)
 }
 
+func replaceSyslogHostReceiverPort(cfg string, receiverPort int) string {
+	return strings.Replace(cfg, "54527", strconv.Itoa(receiverPort), 1)
+}
+
+func replaceSyslogF5ReceiverPort(cfg string, receiverPort int) string {
+	return strings.Replace(cfg, "54526", strconv.Itoa(receiverPort), 1)
+}
+
 func replaceDynatraceExporterEndpoint(cfg string, exporterPort int) string {
 	r := strings.NewReplacer(
 		"${env:DT_ENDPOINT}", fmt.Sprintf("http://0.0.0.0:%v", exporterPort),


### PR DESCRIPTION
This PR adds the syslog ingest example from the [Dynatrace Documentation](https://docs.dynatrace.com/docs/extend-dynatrace/opentelemetry/collector/use-cases/syslog) as well as integration tests for it.