### PR TITLE
chore: add markdown-link-check config

### DIFF
--- a/.markdown_link_check_config.json
+++ b/.markdown_link_check_config.json
@@ -1,0 +1,17 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "http(s)?://\\d+\\.\\d+\\.\\d+\\.\\d+"
+    },
+    {
+      "pattern": "http(s)?://localhost"
+    },
+    {
+      "pattern": "http(s)?://example.com"
+    },
+    {
+      "pattern": "^#"
+    }
+  ],
+  "aliveStatusCodes": [429, 200]
+}


### PR DESCRIPTION
Looks like we forgot to add the markdown-lint-check config file in #191 :slightly_smiling_face: 