### PR TITLE
fix(eecprovider): Fix authentication header format

### DIFF
--- a/internal/confmap/provider/eecprovider/provider.go
+++ b/internal/confmap/provider/eecprovider/provider.go
@@ -34,7 +34,8 @@ const (
 	EECScheme SchemeType = "eec"
 )
 
-const ApiTokenHeader = "Api-Token"
+const AuthHeaderKey = "Authorization"
+const ApiTokenPrefix = "Api-Token "
 
 type provider struct {
 	caCertPath         string // Used for tests
@@ -143,7 +144,7 @@ func (p *provider) Retrieve(ctx context.Context, uri string, watcherFunc confmap
 			return nil, err
 		}
 		if cfg.authToken != "" {
-			req.Header.Add(ApiTokenHeader, cfg.authToken)
+			req.Header.Add(AuthHeaderKey, ApiTokenPrefix + cfg.authToken)
 		}
 		return req, nil
 	}

--- a/internal/confmap/provider/eecprovider/provider.go
+++ b/internal/confmap/provider/eecprovider/provider.go
@@ -32,10 +32,10 @@ type SchemeType string
 
 const (
 	EECScheme SchemeType = "eec"
-)
 
-const AuthHeaderKey = "Authorization"
-const ApiTokenPrefix = "Api-Token "
+	AuthHeaderKey = "Authorization"
+	ApiTokenPrefixFormat = "Api-Token %s"
+)
 
 type provider struct {
 	caCertPath         string // Used for tests
@@ -144,7 +144,7 @@ func (p *provider) Retrieve(ctx context.Context, uri string, watcherFunc confmap
 			return nil, err
 		}
 		if cfg.authToken != "" {
-			req.Header.Add(AuthHeaderKey, ApiTokenPrefix + cfg.authToken)
+			req.Header.Add(AuthHeaderKey, fmt.Sprintf(ApiTokenPrefixFormat, cfg.authToken))
 		}
 		return req, nil
 	}

--- a/internal/confmap/provider/eecprovider/provider_test.go
+++ b/internal/confmap/provider/eecprovider/provider_test.go
@@ -480,7 +480,7 @@ func TestFragmentConfiguration(t *testing.T) {
 			fmt.Println("Write failed: ", err)
 		}
 
-		require.Equal(t, token, req.Header.Get(ApiTokenHeader))
+		require.Equal(t, ApiTokenPrefix + token, req.Header.Get(AuthHeaderKey))
 
 		wg.Done()
 	}

--- a/internal/confmap/provider/eecprovider/provider_test.go
+++ b/internal/confmap/provider/eecprovider/provider_test.go
@@ -480,7 +480,7 @@ func TestFragmentConfiguration(t *testing.T) {
 			fmt.Println("Write failed: ", err)
 		}
 
-		require.Equal(t, ApiTokenPrefix + token, req.Header.Get(AuthHeaderKey))
+		require.Equal(t, "Api-Token " + token, req.Header.Get("Authorization"))
 
 		wg.Done()
 	}


### PR DESCRIPTION
The EEC config provider was mistakenly sending `Api-Token: xxx` in the headers instead of `Authorization: Api-Token xxx`.