### PR TITLE
[chore]: fail testsuite when one of the tests fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BIN_DIR = bin
 SRC_ROOT := $(shell git rev-parse --show-toplevel)
 
 # ALL_MODULES includes ./* dirs (excludes . dir)
-ALL_MODULES := $(shell find . -type f -name "go.mod" -not -path "./build/*" -not -path "./internal/tools/*" -exec dirname {} \; | sort | grep -E '^./' )
+ALL_MODULES := $(shell find . -type f -name "go.mod" -not -path "./build/*" -not -path "./internal/tools/*" -not -path "./internal/k8stest/*" -exec dirname {} \; | sort | grep -E '^./' )
 # Append root module to all modules
 GOMODULES = $(ALL_MODULES)
 
@@ -40,11 +40,13 @@ build-all: .goreleaser.yaml $(GORELEASER) $(MAIN)
 	$(GORELEASER) build --snapshot --clean
 generate: $(MAIN) $(CP_FILES_DEST)
 test: $(BIN)
+	@result=0; \
 	for MOD in $(GOMODULES); do \
 		cd $${MOD}; \
-		go test ./...; \
+		go test -v ./... || result=1; \
 		cd -; \
-	done
+	done; \
+	exit $$result;
 clean:
 	rm -rf $(BUILD_DIR) $(DIST_DIR) $(BIN_DIR)
 clean-tools:

--- a/internal/testbed/integration/statsd/e2e_test.go
+++ b/internal/testbed/integration/statsd/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package statsd
 
 import (

--- a/internal/testbed/testdata/config-allcomponents.yaml
+++ b/internal/testbed/testdata/config-allcomponents.yaml
@@ -1,4 +1,8 @@
 receivers:
+  statsd:
+    endpoint: "localhost:8125"
+  zipkin:
+    endpoint: "localhost:9411"
   filelog:
     include: [/dev/null]
   fluentforward:


### PR DESCRIPTION
## Changes

- fixes failing all-components test by adding missing statsd and zipkin receivers
- fixes statsd e2e test by adding the `//go build e2e` comment to add it to the correct CI run
- adapted Makefile to fail CI step when one of the test fails, but continue with execution of the rest of the tests, run [here](https://github.com/Dynatrace/dynatrace-otel-collector/actions/runs/10141462064/job/28038753215?pr=250)