### PR TITLE
fix: add missing dependency to sh for RPM linux packages

### DIFF
--- a/.chloggen/add-missing-dep.yaml
+++ b/.chloggen/add-missing-dep.yaml
@@ -1,0 +1,18 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: release
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add missing dependency to /bin/sh to the RPM linux package
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [264]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,6 +67,10 @@ nfpms:
       - apk
       - deb
       - rpm
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
     maintainer: "Dynatrace LLC <opensource@dynatrace.com>"
     vendor: "Dynatrace LLC"
     description: Dynatrace distribution of the OpenTelemetry Collector

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,7 +6,15 @@ This document describes the steps to release a new version of the Dynatrace dist
 
 Before starting a release, make a PR against to verify and update the following:
 
-1. Ensure `manifest.yaml` contains all desired Collector components at the
+1. Make sure that there were no updates to the linux packages
+   - check the goreleaser files upstream for changes under the `nfpms` key
+   - check the upstream installation lifecycle scripts as well as the service config files for changes:
+     - `postinstall.sh`
+     - `preinstall.sh`
+     - `preremove.sh`
+     - `otelcol.conf`
+     - `otelcol.service`
+2. Ensure `manifest.yaml` contains all desired Collector components at the
    desired version. It is recommended that the component versions depend on the
    same minor version of the Collector. For components in the upstream Collector
    repos, most of the time this means they will be the same version as the


### PR DESCRIPTION
This PR synchronizes the distro linux packages with upstream updates from https://github.com/open-telemetry/opentelemetry-collector-releases/pull/617 and https://github.com/open-telemetry/opentelemetry-collector-releases/pull/620.