### PR TITLE
[chore] disable load tests on PRs to reduce runtime cost in the future

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -6,8 +6,6 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+*"
     paths-ignore:
       - "**/README.md"
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Load tests can still be triggered manually for feature branches, just the automatic running will be disabled.