### PR TITLE
[chore] use bigger runner for load tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -152,7 +152,7 @@ jobs:
           go test -v --tags=e2e
 
   combined-load-test:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: "Linux-x64-16-64GB-Runner" # Ubuntu 24.04
     needs: docker-build
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -152,6 +152,7 @@ jobs:
           go test -v --tags=e2e
 
   combined-load-test:
+    if: github.event_name == 'push'
     runs-on: "Linux-x64-16-64GB-Runner" # Ubuntu 24.04
     needs: docker-build
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,9 +7,10 @@ on:
 defaults:
   run:
     shell: bash
+env:
+  KUBECONFIG: /tmp/kube-config-collector-e2e-testing
 
 jobs:
-
   docker-build:
     runs-on: ubuntu-24.04
     steps:
@@ -86,8 +87,6 @@ jobs:
           path: /tmp/dynatrace-otel-collector.tar
 
   k8s-e2e-test-matrix:
-    env:
-      KUBECONFIG: /tmp/kube-config-collector-e2e-testing
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +149,61 @@ jobs:
       - name: Run e2e tests
         run: |
           cd internal/testbed/integration/${{ matrix.usecase }}
+          go test -v --tags=e2e
+
+  combined-load-test:
+    runs-on: "Linux-x64-16-64GB-Runner" # Ubuntu 24.04
+    needs: docker-build
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "~1.22.6"
+          check-latest: true
+          cache: false
+
+      - name: Cache tools
+        id: cache-tools
+        uses: actions/cache@v4
+        with:
+          path: .tools
+          key: e2e-tools-${{ runner.os }}-${{ hashFiles('internal/tools/go.sum') }}
+
+      - name: Install tools
+        if: steps.cache-tools.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p .tools
+          touch .tools/*
+          make install-tools
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.10.0
+        with:
+          node_image: "kindest/node:v1.27.11"
+          kubectl_version: "v1.27.11"
+          cluster_name: kind
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dynatrace-otel-collector-image
+          path: /tmp
+
+      - name: Load Docker image
+        run: |
+          docker load --input /tmp/dynatrace-otel-collector.tar
+
+      - name: Load Image into Kind
+        shell: bash
+        run: |
+          kind load docker-image dynatrace-otel-collector:e2e-test --name kind
+
+      - name: Run e2e tests
+        run: |
+          cd internal/testbed/integration/combinedload
           go test -v --tags=e2e
 
   eec-confmap-provider:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -96,7 +96,6 @@ jobs:
           - zipkin
           - statsd
           - redaction
-          - combinedload
     runs-on: ubuntu-latest
     needs: docker-build
     steps:

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -57,7 +57,9 @@ jobs:
           path: ./bin/*
 
   loadtest:
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: "Dynatrace-OTel-Runners"
+      labels: "Linux-x64-16-64GB-Runner"
     needs: [setup-environment]
     steps:
       - name: Check out code

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -59,7 +59,6 @@ jobs:
   loadtest:
     runs-on:
       group: "Dynatrace-OTel-Runners"
-      labels: "Linux-x64-16-64GB-Runner"
     needs: [setup-environment]
     steps:
       - name: Check out code

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -57,8 +57,7 @@ jobs:
           path: ./bin/*
 
   loadtest:
-    runs-on:
-      group: "Dynatrace-OTel-Runners"
+    runs-on: "Linux-x64-16-64GB-Runner"
     needs: [setup-environment]
     steps:
       - name: Check out code

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -57,7 +57,7 @@ jobs:
           path: ./bin/*
 
   loadtest:
-    runs-on: "Linux-x64-16-64GB-Runner"
+    runs-on: "Linux-x64-16-64GB-Runner" # Ubuntu 24.04
     needs: [setup-environment]
     steps:
       - name: Check out code


### PR DESCRIPTION
This PR changes the runner for our load tests to our new github hosted larger runner with 16 core. 