### PR TITLE
[chore] add check for enhancements in release notes template

### DIFF
--- a/.chloggen/summary.tmpl
+++ b/.chloggen/summary.tmpl
@@ -28,7 +28,7 @@ vXX.YY.ZZ:
 
 </details>
 
-{{- if or .BreakingChanges .Deprecations .NewComponents .BugFixes }}
+{{- if or .BreakingChanges .Deprecations .NewComponents .BugFixes .Enhancements }}
 
 #### Dynatrace distribution changelog:
 


### PR DESCRIPTION
Before that, the dynatrace distribution section was not added to the generated changelog if there have only been changes marked as enhancement since the previous release