### PR TITLE
[chore] pin markdown-link-check version to last working one

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ env:
   # renovate: datasource=golang-version depName=go
   GO_VERSION: "1.23.3"
   # renovate: datasource=github-releases depName=tcort/markdown-link-check
-  MARKDOWN_LINK_CHECK_VERSION: "v3.13.6"
+  MARKDOWN_LINK_CHECK_VERSION: "v3.12.2"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
markdown-link-check has some issue in newer versions that's not fixed yet. (see https://github.com/tcort/markdown-link-check/issues/369)
This PR pins the version to last known working one: 3.12.2