### PR TITLE
[chore] remove deprecated regexMatcher from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": ["^(go\\.opentelemetry\\.io/collector|github\\.com/open-telemetry/opentelemetry-collector-contrib)"],
+      "matchPackagePatterns": ["/^(go\\.opentelemetry\\.io/collector|github\\.com/open-telemetry/opentelemetry-collector-contrib)/"],
       "matchPackageNames": ["open-telemetry/opentelemetry-collector-contrib"],
       "groupName": "OpenTelemetry Collector"
     },
@@ -37,15 +37,9 @@
         "(^|\\/).*\\.sh$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*(:|=|\\?=|:=|\\+=) ?\\\"?(?<currentValue>.+?)?\\\"?\\s"
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*(:|=|\\?=|:=|\\+=) ?\\\"?(?<currentValue>.+?)?\\\"?\\s",
+        "- gomod: (?<depName>(go\\.opentelemetry\\.io\/collector|github\\.com\/open-telemetry\/opentelemetry-collector-contrib|github\\.com\/dynatrace\/dynatrace-otel-collector)\/([A-Za-z0-9]+\/)*[A-Za-z0-9]+) (?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
       ]
     }
-  ],
-  "regexManagers": [
-      {
-        "fileMatch": ["^manifest.yaml$"],
-        "matchStrings": ["- gomod: (?<depName>(go\\.opentelemetry\\.io\/collector|github\\.com\/open-telemetry\/opentelemetry-collector-contrib|github\\.com\/dynatrace\/dynatrace-otel-collector)\/([A-Za-z0-9]+\/)*[A-Za-z0-9]+) (?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"],
-        "datasourceTemplate": "github-releases"
-      }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -45,7 +45,7 @@
       "fileMatch": [
         "^manifest.yaml$"
       ],
-      "datasourceTemplate": "github-releases",
+      "datasourceTemplate": "go",
       "matchStrings": [
         "- gomod: (?<depName>(go\\.opentelemetry\\.io\/collector|github\\.com\/open-telemetry\/opentelemetry-collector-contrib|github\\.com\/dynatrace\/dynatrace-otel-collector)\/([A-Za-z0-9]+\/)*[A-Za-z0-9]+) (?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": ["/^(go\\.opentelemetry\\.io/collector|github\\.com/open-telemetry/opentelemetry-collector-contrib)/"],
+      "matchPackagePatterns": ["/^(go\\.opentelemetry\\.io\/collector|github\\.com\/open-telemetry\/opentelemetry-collector-contrib)\/"],
       "matchPackageNames": ["open-telemetry/opentelemetry-collector-contrib"],
       "groupName": "OpenTelemetry Collector"
     },
@@ -45,6 +45,7 @@
       "fileMatch": [
         "^manifest.yaml$"
       ],
+      "datasourceTemplate": "go",
       "matchStrings": [
         "- gomod: (?<depName>(go\\.opentelemetry\\.io\/collector|github\\.com\/open-telemetry\/opentelemetry-collector-contrib|github\\.com\/dynatrace\/dynatrace-otel-collector)\/([A-Za-z0-9]+\/)*[A-Za-z0-9]+) (?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": ["/^(go\\.opentelemetry\\.io\/collector|github\\.com\/open-telemetry\/opentelemetry-collector-contrib)\/"],
+      "matchPackagePatterns": ["^(go\\.opentelemetry\\.io\/collector|github\\.com\/open-telemetry\/opentelemetry-collector-contrib)\/"],
       "matchPackageNames": ["open-telemetry/opentelemetry-collector-contrib"],
       "groupName": "OpenTelemetry Collector"
     },
@@ -45,7 +45,7 @@
       "fileMatch": [
         "^manifest.yaml$"
       ],
-      "datasourceTemplate": "go",
+      "datasourceTemplate": "github-releases",
       "matchStrings": [
         "- gomod: (?<depName>(go\\.opentelemetry\\.io\/collector|github\\.com\/open-telemetry\/opentelemetry-collector-contrib|github\\.com\/dynatrace\/dynatrace-otel-collector)\/([A-Za-z0-9]+\/)*[A-Za-z0-9]+) (?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,15 @@
         "(^|\\/).*\\.sh$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*(:|=|\\?=|:=|\\+=) ?\\\"?(?<currentValue>.+?)?\\\"?\\s",
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*(:|=|\\?=|:=|\\+=) ?\\\"?(?<currentValue>.+?)?\\\"?\\s"
+      ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^manifest.yaml$"
+      ],
+      "matchStrings": [
         "- gomod: (?<depName>(go\\.opentelemetry\\.io\/collector|github\\.com\/open-telemetry\/opentelemetry-collector-contrib|github\\.com\/dynatrace\/dynatrace-otel-collector)\/([A-Za-z0-9]+\/)*[A-Za-z0-9]+) (?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
       ]
     }


### PR DESCRIPTION
Tested on fork: https://github.com/odubajDT/dynatrace-otel-collector/pull/11/files