### PR TITLE
[chore] increase limits for load tests

### DIFF
--- a/internal/testbed/load/tests/metrics_test.go
+++ b/internal/testbed/load/tests/metrics_test.go
@@ -55,7 +55,7 @@ func TestMetric10kDPS(t *testing.T) {
 				},
 				resourceSpec: testbed.ResourceSpec{
 					ExpectedMaxCPU: 60,
-					ExpectedMaxRAM: 125,
+					ExpectedMaxRAM: 150,
 				},
 				attrCount:       25,
 				attrSizeByte:    20,
@@ -75,7 +75,7 @@ func TestMetric10kDPS(t *testing.T) {
 				},
 				resourceSpec: testbed.ResourceSpec{
 					ExpectedMaxCPU: 60,
-					ExpectedMaxRAM: 120,
+					ExpectedMaxRAM: 150,
 				},
 				attrCount:       25,
 				attrSizeByte:    20,
@@ -121,7 +121,7 @@ func TestMetric100kDPS(t *testing.T) {
 				},
 				resourceSpec: testbed.ResourceSpec{
 					ExpectedMaxCPU: 70,
-					ExpectedMaxRAM: 120,
+					ExpectedMaxRAM: 150,
 				},
 				attrCount:       25,
 				attrSizeByte:    20,
@@ -141,7 +141,7 @@ func TestMetric100kDPS(t *testing.T) {
 				},
 				resourceSpec: testbed.ResourceSpec{
 					ExpectedMaxCPU: 105,
-					ExpectedMaxRAM: 120,
+					ExpectedMaxRAM: 150,
 				},
 				attrCount:       25,
 				attrSizeByte:    20,

--- a/internal/testbed/load/tests/trace_test.go
+++ b/internal/testbed/load/tests/trace_test.go
@@ -27,7 +27,7 @@ func TestTrace10kSPS(t *testing.T) {
 				},
 				resourceSpec: testbed.ResourceSpec{
 					ExpectedMaxCPU: 30,
-					ExpectedMaxRAM: 120,
+					ExpectedMaxRAM: 150,
 				},
 				attrCount:       10,
 				attrSizeByte:    50,
@@ -47,7 +47,7 @@ func TestTrace10kSPS(t *testing.T) {
 				},
 				resourceSpec: testbed.ResourceSpec{
 					ExpectedMaxCPU: 30,
-					ExpectedMaxRAM: 120,
+					ExpectedMaxRAM: 150,
 				},
 				attrCount:       10,
 				attrSizeByte:    50,
@@ -92,7 +92,7 @@ func TestTrace100kSPS(t *testing.T) {
 				},
 				resourceSpec: testbed.ResourceSpec{
 					ExpectedMaxCPU: 90,
-					ExpectedMaxRAM: 120,
+					ExpectedMaxRAM: 150,
 				},
 				attrCount:       10,
 				attrSizeByte:    50,
@@ -112,7 +112,7 @@ func TestTrace100kSPS(t *testing.T) {
 				},
 				resourceSpec: testbed.ResourceSpec{
 					ExpectedMaxCPU: 110,
-					ExpectedMaxRAM: 120,
+					ExpectedMaxRAM: 150,
 				},
 				attrCount:       10,
 				attrSizeByte:    50,


### PR DESCRIPTION
According to the recent results https://dynatrace.github.io/dynatrace-otel-collector/benchmarks/loadtests/ there was no significant or sudden increase in the memory consumption, but it was always rather close to the specified limits