### PR TITLE
Add builds for ppc64le and s390x architectures

### DIFF
--- a/.chloggen/ppcle-s390x-arch-support.yaml
+++ b/.chloggen/ppcle-s390x-arch-support.yaml
@@ -1,0 +1,18 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: release
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add builds for ppc64le and s390x architectures
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [424]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ env:
   # renovate: datasource=golang-version depName=go
   GO_VERSION: "1.23.4"
   # renovate: datasource=github-releases depName=tcort/markdown-link-check
-  MARKDOWN_LINK_CHECK_VERSION: "v3.13.6"
+  MARKDOWN_LINK_CHECK_VERSION: "v3.12.2"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - uses: docker/setup-qemu-action@v3
         with:
-          platforms: arm64
+          platforms: arm64,ppc64le,s390x
       - uses: docker/setup-buildx-action@v3
       - uses: anchore/sbom-action/download-syft@v0.17.9
       - name: Cache tools

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: docker/setup-qemu-action@v3
         with:
-          platforms: arm64
+          platforms: arm64,ppc64le,s390x
 
       - uses: docker/setup-buildx-action@v3
 
@@ -90,7 +90,7 @@ jobs:
 
       - uses: docker/setup-qemu-action@v3
         with:
-          platforms: arm64
+          platforms: arm64,ppc64le,s390x
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -122,8 +122,6 @@ dockers:
       - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:latest-ppc64le
       - public.ecr.aws/dynatrace/dynatrace-otel-collector:{{ .Version }}-ppc64le
       - public.ecr.aws/dynatrace/dynatrace-otel-collector:latest-ppc64le
-    extra_files:
-      - config.yaml
     build_flag_templates:
       - --pull
       - --platform=linux/ppc64le
@@ -142,8 +140,6 @@ dockers:
       - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:latest-s390x
       - public.ecr.aws/dynatrace/dynatrace-otel-collector:{{ .Version }}-s390x
       - public.ecr.aws/dynatrace/dynatrace-otel-collector:latest-s390x
-    extra_files:
-      - config.yaml
     build_flag_templates:
       - --pull
       - --platform=linux/s390x

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,9 +21,15 @@ builds:
     goarch:
       - amd64
       - arm64
+      - ppc64le
+      - s390x
     ignore:
       - goos: windows
         goarch: arm64
+      - goos: darwin
+        goarch: s390x
+      - goos: windows
+        goarch: s390x
     dir: build
 
 sboms:
@@ -108,23 +114,71 @@ dockers:
       - --label=org.opencontainers.image.version={{.Version}}
       - --label=org.opencontainers.image.source={{.GitURL}}
     use: buildx
+  - goos: linux
+    goarch: ppc64le
+    dockerfile: Dockerfile
+    image_templates:
+      - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:{{ .Version }}-ppc64le
+      - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:latest-ppc64le
+      - public.ecr.aws/dynatrace/dynatrace-otel-collector:{{ .Version }}-ppc64le
+      - public.ecr.aws/dynatrace/dynatrace-otel-collector:latest-ppc64le
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --platform=linux/ppc64le
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
+  - goos: linux
+    goarch: s390x
+    dockerfile: Dockerfile
+    image_templates:
+      - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:{{ .Version }}-s390x
+      - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:latest-s390x
+      - public.ecr.aws/dynatrace/dynatrace-otel-collector:{{ .Version }}-s390x
+      - public.ecr.aws/dynatrace/dynatrace-otel-collector:latest-s390x
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --platform=linux/s390x
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
 docker_manifests:
   - name_template: ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:{{ .Version }}
     image_templates:
       - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:{{ .Version }}-amd64
       - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:{{ .Version }}-arm64
+      - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:{{ .Version }}-ppc64le
+      - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:{{ .Version }}-s390x
   - name_template: ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:latest
     image_templates:
       - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:latest-amd64
       - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:latest-arm64
+      - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:latest-ppc64le
+      - ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:latest-s390x
   - name_template: public.ecr.aws/dynatrace/dynatrace-otel-collector:{{ .Version }}
     image_templates:
       - public.ecr.aws/dynatrace/dynatrace-otel-collector:{{ .Version }}-amd64
       - public.ecr.aws/dynatrace/dynatrace-otel-collector:{{ .Version }}-arm64
+      - public.ecr.aws/dynatrace/dynatrace-otel-collector:{{ .Version }}-ppc64le
+      - public.ecr.aws/dynatrace/dynatrace-otel-collector:{{ .Version }}-s390x
   - name_template: public.ecr.aws/dynatrace/dynatrace-otel-collector:latest
     image_templates:
       - public.ecr.aws/dynatrace/dynatrace-otel-collector:latest-amd64
       - public.ecr.aws/dynatrace/dynatrace-otel-collector:latest-arm64
+      - public.ecr.aws/dynatrace/dynatrace-otel-collector:latest-ppc64le
+      - public.ecr.aws/dynatrace/dynatrace-otel-collector:latest-s390x
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -97,6 +97,7 @@ dockers:
       - --label=org.opencontainers.image.revision={{.FullCommit}}
       - --label=org.opencontainers.image.version={{.Version}}
       - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
   - goos: linux
     goarch: arm64
@@ -113,6 +114,7 @@ dockers:
       - --label=org.opencontainers.image.revision={{.FullCommit}}
       - --label=org.opencontainers.image.version={{.Version}}
       - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
   - goos: linux
     goarch: ppc64le

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For help troubleshooting issues, please see the OpenTelemetry documentation on [
 
 ## Support
 
-This x86-64 and ARM64 builds of this distribution are supported by the Dynatrace Support team, as described on the Dynatrace [support page].
+The x86-64 and ARM64 builds of this distribution are supported by the Dynatrace Support team, as described on the Dynatrace [support page].
 For issues reported via GitHub, support contracts and SLAs do not apply.
 Please reach out via our official support channels for full coverage.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For help troubleshooting issues, please see the OpenTelemetry documentation on [
 
 ## Support
 
-This distribution (specifically, only its ARM64 and x86-64 variants) is supported by the Dynatrace Support team, as described on the Dynatrace [support page].
+This x86-64 and ARM64 builds of this distribution are supported by the Dynatrace Support team, as described on the Dynatrace [support page].
 For issues reported via GitHub, support contracts and SLAs do not apply.
 Please reach out via our official support channels for full coverage.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For help troubleshooting issues, please see the OpenTelemetry documentation on [
 
 ## Support
 
-This distribution is supported by the Dynatrace Support team, as described on the Dynatrace [support page].
+This distribution (specifically, only its ARM64 and x86-64 variants) is supported by the Dynatrace Support team, as described on the Dynatrace [support page].
 For issues reported via GitHub, support contracts and SLAs do not apply.
 Please reach out via our official support channels for full coverage.
 


### PR DESCRIPTION
### This PR
- adds builds for ppc64le and s390x architectures
- adapts the support statement
- adds missing license OCI labels to container images