### PR TITLE
[chore] fix expected service name for prometheus e2e test

### DIFF
--- a/internal/testbed/integration/prometheus/e2e_test.go
+++ b/internal/testbed/integration/prometheus/e2e_test.go
@@ -84,7 +84,7 @@ func TestE2E_PrometheusNodeExporter(t *testing.T) {
 	expectedColMetrics := []string{
 		"otelcol_process_memory_rss", "scrape_duration_seconds", "scrape_samples_post_metric_relabeling",
 	}
-	oteltest.ScanForServiceMetrics(t, metricsConsumer, "opentelemetry-collector", expectedColMetrics)
+	oteltest.ScanForServiceMetrics(t, metricsConsumer, "dynatrace-otel-collector", expectedColMetrics)
 
 	expectedPromMetrics := []string{
 		"node_procs_running", "node_memory_MemAvailable_bytes",


### PR DESCRIPTION
The metrics exposed by the collector's self monitoring prometheus endpoint at port `8888` contain a `service_name="dynatrace-otel-collector"` label, which is used for the resulting  resource name.
Previously, apparently the job name from the prometheus config has been used for the service name:

```
        - job_name: opentelemetry-collector
          scrape_interval: 60s
          static_configs:
            - targets:
                - 127.0.0.1:8888
 ```

I'm not 100% sure yet why this has changed with the new upstream release, but my guess is that this is linked to the recent major version upgrade of the prometheus dependency: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36873

Update: It seems like since the prometheus version upgrade, the prometheus scrape manager will convert the `service_name` label provided by the collector self monitoring metrics to `service.name`, which is then set as a resource attribute by the prometheus receiver, overriding the previous `service.name` value determined by the `job` label
