### PR TITLE
[chore] fix the self monitoring config

### DIFF
--- a/docs/dashboards/README.md
+++ b/docs/dashboards/README.md
@@ -72,7 +72,8 @@ service:
                 temporality_preference: delta
                 endpoint: "${env:DT_ENDPOINT}/v1/metrics"
                 headers:
-                  Authorization: "Api-Token ${env:DT_API_TOKEN}"
+                  - name: Authorization
+                    value: "Api-Token ${env:DT_API_TOKEN}"
 ```
 
 Note that the OTel collector can automatically merge configuration files for you, so by assuming the above configuration is stored in a file called `selfmon-config.yaml`, it is possible to start the collector like this:


### PR DESCRIPTION
The config scheme upstream has been changed to v0.3 where the headers have to be provided as a list of key value pairs: https://github.com/open-telemetry/opentelemetry-collector/blob/58f3efbc35483c478d785ecea50a467ce1602707/service/telemetry/internal/migration/v0.3.0.go#L30

I noticed that If the headers are provided with the old scheme, parsing the config as v0.3 will fail, and v0.2 will be used as a fallback - the endpoint and authorization config will still be set in that case, however the `temporality_preference` will not be applied correctly in this case, leading many self monitoring metrics to be rejected by Dynatrace.
This PR fixes this by following the new scheme.