### PR TITLE
[chore] add previous tag to changelog template

### DIFF
--- a/.chloggen/summary.tmpl
+++ b/.chloggen/summary.tmpl
@@ -88,3 +88,5 @@ vXX.YY.ZZ:
 {{- end }}
 
 {{- end }}
+
+<!-- previous-version -->

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,11 @@ jobs:
         with:
           registry-type: public
 
+      - name: Extract changelog
+        run: awk '/<!-- next version -->/,/<!-- previous-version -->/' CHANGELOG.md > ./release-notes.md
+
       - name: Create release for version tag
         run: make release
         env:
+          RELEASE_NOTES: "./release-notes.md"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ install-tools: install-go-junit-report $(TOOLS_BIN_NAMES)
 snapshot: .goreleaser.yaml $(GORELEASER)
 	$(GORELEASER) release --snapshot --clean --parallelism 2 --skip sbom
 release: .goreleaser.yaml $(GORELEASER)
-	$(GORELEASER) release --clean --parallelism 2
+	$(GORELEASER) release --clean --parallelism 2 --release-notes $(RELEASE_NOTES)
 
 $(TOOLS_BIN_DIR):
 	mkdir -p $@


### PR DESCRIPTION
This PR populates the github releases notes with the generated changelog from chloggen removing a manual step to copy/paste the release notes into the github release.