### PR TITLE
[chore] add Lychee link scanning for the complete repo

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,44 @@
+# This action requires that any PR targeting the main branch should touch at
+# least one CHANGELOG file. If a CHANGELOG entry is not required, add the "Skip
+# Changelog" label to disable this action.
+
+name: 'Check Links'
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 4 * * 1" # Run at 04:00 UTC on Mondays.
+
+env:
+  # renovate: datasource=golang-version depName=go
+  GO_VERSION: "1.23.6"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6 # v2.3.0
+        with:
+          fail: ${{ github.event_name != 'schedule' }}
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0 && github.event_name == 'schedule'
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
+        with:
+          title: Lychee found some broken links
+          content-filepath: ./lychee/out.md
+          labels: bug

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   # renovate: datasource=golang-version depName=go
   GO_VERSION: "1.23.6"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,6 @@ The following section describes how setup your environment and build the collect
 
 You will need the `make` command which usually comes with some package such as `build-essential`.
 You will also need to install an appropriate version of `go`.
-Look at the current [`go.mod`](./go.mod) file to see the minimum `go` version.
 All other required tools are installed automatically by `make`.
 
 ### Installing build tools

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -61,4 +61,4 @@ Once you have completed the above steps, the [Build and Release](../.github/work
 
 **Note:**
 
-After the release is completed, please do not forget to merge the automated renovate version update PRs for `dynatrace-otel-collector` and `opentelemetry-operator` in the [dynatrace-docs](https://bitbucket.lab.dynatrace.org/projects/SUS/repos/dynatrace-docs/browse) repository. Please be aware that automatic creation of these PRs by renovate-bot might take a few hours.
+After the release is completed, please do not forget to merge the automated renovate version update PRs for `dynatrace-otel-collector` and `opentelemetry-operator` in the dynatrace-docs repository. Please be aware that automatic creation of these PRs by renovate-bot might take a few hours.

--- a/lychee.toml
+++ b/lychee.toml
@@ -6,7 +6,8 @@ exclude  = [
     "http(s)?://localhost",
     "http(s)?://example.com",
     "https://github.com/open-telemetry/opentelemetry-collector(-contrib)?/releases/tag/vXX.YY.ZZ",
-    "http(s)?://\\d+\\.\\d+\\.\\d+\\.\\d+"
+    "http(s)?://\\d+\\.\\d+\\.\\d+\\.\\d+",
+    "https://hub.docker.com/repository/docker/dynatrace/dynatrace-otel-collector"
 ]
 
 # better to be safe and avoid failures


### PR DESCRIPTION
This PR adds lychee link scanning on PRs and on push to main for the complete repo.
It also runs the link checker every monday morning and will file an issue if broken links come up.