### PR TITLE
[chore] Adapt Linux package script changes from v0.122.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,10 @@ v0.122.0:
 
 - `receiver/netflow`: Include the netflow receiver in the distribution (#489)
 
+### 🧰 Bug fixes 🧰
+
+- `linux packages`: Ensure Linux package scripts work in chrooted environments without Systemd running
+
 <!-- previous-version -->
 
 ## 0.25.0

--- a/internal/release/postinstall.sh
+++ b/internal/release/postinstall.sh
@@ -16,10 +16,14 @@
 # limitations under the License.
 
 if command -v systemctl >/dev/null 2>&1; then
-    systemctl daemon-reload
+    if [ -d /run/systemd/system ]; then
+      systemctl daemon-reload
+    fi
     systemctl enable dynatrace-otel-collector.service
     if [ -f /etc/dynatrace-otel-collector/config.yaml ]; then
+      if [ -d /run/systemd/system ]; then
         systemctl restart dynatrace-otel-collector.service
+      fi
     else
       echo "Collector installed, but no config.yaml was found, skipping startup..."
     fi


### PR DESCRIPTION
There was an upstream change in the [`postinstall.sh` script ](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/v0.122.0/distributions/otelcol/postinstall.sh) that solves for situations where the script is run in a chroot and Systemd isn't running, even though it is used on the host system and the `systemctl` binary is available.