### PR TITLE
[chore] add generated release notes file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ lib/
 .idea
 cmd/oteltestbedcol/*
 !cmd/oteltestbedcol/.gitkeep
+release-notes.md


### PR DESCRIPTION
Due to the recent change in generation of [chlog](https://github.com/Dynatrace/dynatrace-otel-collector/commit/373831d562febd94a0be32e7160277b87743cbaa), the generated file needs to be added to gitignore, as goreleaser is not able to do the release unless the git tree is clean

Failed release https://github.com/Dynatrace/dynatrace-otel-collector/actions/runs/13986624830/job/39161391053