### PR TITLE
[chore] generate CycloneDX SBOM using `cyclonedx-gomod`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
           platforms: arm64,ppc64le,s390x
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - name: Install cyclonedx-gomod
+        # renovate: datasource=go depName=github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod
         run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.9.0
       - name: Cache tools
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,8 @@ jobs:
         with:
           platforms: arm64,ppc64le,s390x
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-      - uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
+      - name: Install cyclonedx-gomod
+        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.9.0
       - name: Cache tools
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ on:
 env:
   # renovate: datasource=golang-version depName=go
   GO_VERSION: "1.24.1"
+  # renovate: datasource=go depName=github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod
+  CYCLONEDX_VERSION: "v1.9.0"
 
 jobs:
   build:
@@ -38,8 +40,7 @@ jobs:
           platforms: arm64,ppc64le,s390x
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - name: Install cyclonedx-gomod
-        # renovate: datasource=go depName=github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod
-        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.9.0
+        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@${{ env.CYCLONEDX_VERSION }}
       - name: Cache tools
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -11,6 +11,8 @@ concurrency:
 env:
   # renovate: datasource=golang-version depName=go
   GO_VERSION: "1.24.1"
+  # renovate: datasource=go depName=github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod
+  CYCLONEDX_VERSION: "v1.9.0"
 
 jobs:
   build:
@@ -34,8 +36,7 @@ jobs:
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Install cyclonedx-gomod
-        # renovate: datasource=go depName=github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod
-        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.9.0
+        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@${{ env.CYCLONEDX_VERSION }}
 
       - name: Cache tools
         id: cache-tools

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -33,7 +33,8 @@ jobs:
 
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
-      - uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
+      - name: Install cyclonedx-gomod
+        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.9.0
 
       - name: Cache tools
         id: cache-tools

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -34,6 +34,7 @@ jobs:
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Install cyclonedx-gomod
+        # renovate: datasource=go depName=github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod
         run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.9.0
 
       - name: Cache tools

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,21 @@ builds:
     dir: build
 
 sboms:
-  - artifacts: archive
+  - cmd: cyclonedx-gomod
+    args: ["app", "-licenses", "-assert-licenses", "-std", "-json", "-main", "./", "-output", "$document", "../build/"]
+    artifacts: binary
+    env:
+      - GOARCH={{ .Arch }}
+      - GOOS={{ .Os }}
+    documents:
+      - >-
+        {{ .ProjectName }}_
+        {{- .Version }}_
+        {{- title .Os }}_
+        {{- if eq .Arch "amd64" }}x86_64
+        {{- else if eq .Arch "386" }}i386
+        {{- else }}{{ .Arch }}{{- end }}
+        {{- if .Arm }}v{{ .Arm }}{{ end }}-sbom.cdx.json
 
 archives:
   - formats: [ 'tar.gz' ]

--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,16 @@
       "matchStrings": [
         "- gomod: (?<depName>(go\\.opentelemetry\\.io/collector|github\\.com/open-telemetry/opentelemetry-collector-contrib|github\\.com/dynatrace/dynatrace-otel-collector)/([A-Za-z0-9]+/)*[A-Za-z0-9]+) (?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
       ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^\\.github/workflows/.*\\.yaml$"
+      ],
+      "datasourceTemplate": "go",
+      "matchStrings": [
+        "run: go install (?<packageName>github\\.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod)@(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
         "(^|\\/).*\\.sh$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*(:|=|\\?=|:=|\\+=) ?\\\"?(?<currentValue>.+?)?\\\"?\\s"
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*(:|=|\\?=|:=|\\+=|@) ?\\\"?(?<currentValue>.+?)?\\\"?\\s"
       ]
     },
     {
@@ -54,16 +54,6 @@
       "datasourceTemplate": "go",
       "matchStrings": [
         "- gomod: (?<depName>(go\\.opentelemetry\\.io/collector|github\\.com/open-telemetry/opentelemetry-collector-contrib|github\\.com/dynatrace/dynatrace-otel-collector)/([A-Za-z0-9]+/)*[A-Za-z0-9]+) (?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
-      ]
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^\\.github/workflows/.*\\.yaml$"
-      ],
-      "datasourceTemplate": "go",
-      "matchStrings": [
-        "run: go install (?<packageName>github\\.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod)@(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
       ]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
         "(^|\\/).*\\.sh$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*(:|=|\\?=|:=|\\+=|@) ?\\\"?(?<currentValue>.+?)?\\\"?\\s"
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*(:|=|\\?=|:=|\\+=) ?\\\"?(?<currentValue>.+?)?\\\"?\\s"
       ]
     },
     {


### PR DESCRIPTION
- switch from SPDX to CycloneDX to align with publicly available SBOMs for Operator, ActiveGate and dynatrace-configuration-as-code
- use `cyclonedx-gomod` instead of `syft` for more accurate Go package detection, added license information and source repo information (if available)
- generate the SBOM for each binary and store it in a file that follows the existing naming convention for binaries, e.g., `dynatrace-otel-collector_0.0.1-next_Linux_x86_64-sbom.cdx.json`

Changes have been tested in a private fork. 
An example SBOM output can be found here -> [dynatrace-otel-collector_0.0.1-next_Linux_x86_64-sbom.cdx.json](https://github.com/user-attachments/files/19719433/dynatrace-otel-collector_0.0.1-next_Linux_x86_64-sbom.cdx.json).