### PR TITLE
[chore] Fix release version in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 <!-- next version -->
 
-## v0.3.0
+## v0.30.0
 
 This release includes version 0.126.0 of the upstream Collector components.
 


### PR DESCRIPTION
Properly sets the version in the changelog to `v0.30.0`. The manifest version is already correct.