### PR TITLE
[extension/k8sleaderelector] Add extension to distribution

### DIFF
--- a/.chloggen/add-leader-elector.yaml
+++ b/.chloggen/add-leader-elector.yaml
@@ -1,0 +1,18 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: extension/k8sleaderelector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add k8s leader elector extension to the distribution"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [584]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The following components are included in the distribution:
 
 * [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension)
 * [zpagesextension](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/zpagesextension)
+* [k8sleaderelectorextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/k8sleaderelector)
 
 ### Connectors
 

--- a/internal/testbed/testdata/config-allcomponents.yaml
+++ b/internal/testbed/testdata/config-allcomponents.yaml
@@ -165,6 +165,10 @@ connectors:
 
 extensions:
   zpages:
+  k8s_leader_elector:
+    auth_type: "serviceAccount"
+    lease_name: opentelemetry-collector
+    lease_namespace: default
   health_check:
     endpoint: "localhost:13000"
     tls:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -27,6 +27,7 @@ exporters:
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.126.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.126.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.126.0
 
 processors:


### PR DESCRIPTION
Testing of the extension will be part of the [k8s combined instegration test scenario](https://github.com/Dynatrace/dynatrace-otel-collector/pull/581)