### PR TITLE
[chore] use kind node image versions for k8s version in cluster setup…

### DIFF
--- a/.github/actions/create-cluster/action.yaml
+++ b/.github/actions/create-cluster/action.yaml
@@ -9,7 +9,7 @@ inputs:
   k8s-version:
     required: false
     description: "Kubernetes version that should be used"
-    # renovate: datasource=github-releases depName=kubernetes/kubernetes
+    # renovate: datasource=docker depName=kindest/node
     default: "v1.33.0"
   cluster-name:
     required: false


### PR DESCRIPTION
… action

To fix issues like [this PR](https://github.com/Dynatrace/dynatrace-otel-collector/pull/579) where k8s upstream has a newer version than kind supports.