### PR TITLE
[chore] change regex for ocb manifest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,7 @@
     }
   ],
   "ocb": {
-    "managerFilePatterns": ["^manifest.yaml$"]
+    "managerFilePatterns": ["/^manifest.yaml$/"]
   },
   "customManagers": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,7 @@
     }
   ],
   "ocb": {
-    "managerFilePatterns": ["/^manifest.yaml$/"]
+    "managerFilePatterns": ["manifest.yaml"]
   },
   "customManagers": [
     {


### PR DESCRIPTION
This PR adapts the regex for detecting the ocb manifest. With these changes, the components in the manifest are updated again. Verified on a forked repo: https://github.com/bacherfl/dynatrace-otel-collector/pull/2