### PR TITLE
[chore] Revert chore(deps): update dependency go to v1.25.2 (#693)

### DIFF
--- a/.github/actions/create-cluster/action.yaml
+++ b/.github/actions/create-cluster/action.yaml
@@ -21,7 +21,7 @@ inputs:
     default: "./.github/actions/create-cluster/single-node.yaml"
 env:
   # renovate: datasource=golang-version depName=go
-  GO_VERSION: "1.25.2"
+  GO_VERSION: "1.25.1"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # renovate: datasource=golang-version depName=go
-  GO_VERSION: "1.25.2"
+  GO_VERSION: "1.25.1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   # renovate: datasource=golang-version depName=go
-  GO_VERSION: "1.25.2"
+  GO_VERSION: "1.25.1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   # renovate: datasource=golang-version depName=go
-  GO_VERSION: "1.25.2"
+  GO_VERSION: "1.25.1"
 
 jobs:
   build:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,7 @@ defaults:
 env:
   KUBECONFIG: /tmp/kube-config-collector-e2e-testing
   # renovate: datasource=golang-version depName=go
-  GO_VERSION: "1.25.2"
+  GO_VERSION: "1.25.1"
 
 jobs:
   docker-build:

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # renovate: datasource=golang-version depName=go
-  GO_VERSION: "1.25.2"
+  GO_VERSION: "1.25.1"
 
 jobs:
   setup-environment:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   # renovate: datasource=golang-version depName=go
-  GO_VERSION: "1.25.2"
+  GO_VERSION: "1.25.1"
   # renovate: datasource=go depName=github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod
   CYCLONEDX_VERSION: "v1.9.0"
   # renovate: datasource=github-releases depName=goreleaser/goreleaser-pro

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   # renovate: datasource=golang-version depName=go
-  GO_VERSION: "1.25.2"
+  GO_VERSION: "1.25.1"
 
 jobs:
   build:

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 env:
   # renovate: datasource=golang-version depName=go
-  GO_VERSION: "1.25.2"
+  GO_VERSION: "1.25.1"
   # renovate: datasource=github-releases depName=goreleaser/goreleaser-pro
   GORELEASER_PRO_VERSION: v2.12.5
 

--- a/internal/confmap/provider/eecprovider/go.mod
+++ b/internal/confmap/provider/eecprovider/go.mod
@@ -1,6 +1,6 @@
 module github.com/Dynatrace/dynatrace-otel-collector/internal/confmap/provider/eecprovider
 
-go 1.25.2
+go 1.25.1
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/data-ingest-cli/go.mod
+++ b/internal/data-ingest-cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/Dynatrace/dynatrace-otel-collector/internal/data-ingest-cli
 
-go 1.25.2
+go 1.25.1
 
 require (
 	github.com/fluent/fluent-logger-golang v1.10.1

--- a/internal/mockeec/go.mod
+++ b/internal/mockeec/go.mod
@@ -1,3 +1,3 @@
 module github.com/Dynatrace/dynatrace-otel-collector/internal/mockeec
 
-go 1.25.2
+go 1.25.1

--- a/internal/testbed/go.mod
+++ b/internal/testbed/go.mod
@@ -1,6 +1,6 @@
 module github.com/Dynatrace/dynatrace-otel-collector/internal/testbed
 
-go 1.25.2
+go 1.25.1
 
 require (
 	github.com/Dynatrace/dynatrace-otel-collector/internal/testcommon v0.0.0

--- a/internal/testcommon/go.mod
+++ b/internal/testcommon/go.mod
@@ -1,6 +1,6 @@
 module testcommon
 
-go 1.25.2
+go 1.25.1
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.137.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/Dynatrace/dynatrace-otel-collector/internal/tools
 
-go 1.25.2
+go 1.25.1
 
 require (
 	github.com/sigstore/cosign/v2 v2.6.1


### PR DESCRIPTION
This reverts commit af1a2dc20f9b5d56795adfb88c356b4b9821ba34.

# Conflicts:
our snyk action still uses 1.25.1 we need to wait for an update see failing tests [here](https://github.com/Dynatrace/dynatrace-otel-collector/actions/runs/18339570265)