### PR TITLE
chore: ignore 404 link from old changelog

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,6 +2,7 @@
 
 # mentioned in changelog does not exist anymore
 https://github.com/open-telemetry/opentelemetry-collector/issues/44229
+https://github.com/open-telemetry/opentelemetry-collector/pull/14444
 
 # current v2.8.0 has a bug for GitHub Markdown fragment https://github.com/lycheeverse/lychee/issues/1729
 https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.147.x/pkg/stanza/operator/parser/syslog/syslogtest/data.go#L46


### PR DESCRIPTION
fix https://github.com/Dynatrace/dynatrace-otel-collector/actions/runs/24568683302/job/71835612154