### PR TITLE
chore: make kafka integration test more robust

### DIFF
--- a/internal/testbed/integration/kafka/e2e_test.go
+++ b/internal/testbed/integration/kafka/e2e_test.go
@@ -204,12 +204,20 @@ func TestE2E_Kafka(t *testing.T) {
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
 		all := metricsConsumer.AllMetrics()
 		require.NotEmpty(tt, all)
-		got := all[len(all)-1]
-		err := pmetrictest.CompareMetrics(expectedMetrics, got, metricsCompareOptions...)
-		testutil.Debug(err, t, expectedMetrics, got)
-		assert.NoError(tt, err)
-	}, compareTimeout, compareTick)
 
+		var lastErr error
+		for _, got := range all {
+			err := pmetrictest.CompareMetrics(expectedMetrics, got, metricsCompareOptions...)
+			if err == nil {
+				lastErr = nil
+				return
+			}
+			lastErr = err
+		}
+
+		testutil.Debug(lastErr, t, expectedMetrics, all[len(all)-1])
+		assert.NoError(tt, lastErr)
+	}, compareTimeout, compareTick)
 	t.Logf("Metrics checked successfully")
 
 	// Logs

--- a/internal/testbed/integration/kafka/e2e_test.go
+++ b/internal/testbed/integration/kafka/e2e_test.go
@@ -214,8 +214,6 @@ func TestE2E_Kafka(t *testing.T) {
 			}
 			lastErr = err
 		}
-
-		testutil.Debug(lastErr, t, expectedMetrics, all[len(all)-1])
 		assert.NoError(tt, lastErr)
 	}, compareTimeout, compareTick)
 	t.Logf("Metrics checked successfully")

--- a/internal/testbed/integration/kafka/e2e_test.go
+++ b/internal/testbed/integration/kafka/e2e_test.go
@@ -301,7 +301,9 @@ func TestE2E_Kafka(t *testing.T) {
 		all := kmetricsConsumer.AllMetrics()
 		require.NotEmpty(tt, all)
 		got := all[len(all)-1]
-		assert.NoError(tt, pmetrictest.CompareMetrics(expectedKMetrics, got, kmetricsCompareOptions...))
+		err := pmetrictest.CompareMetrics(expectedKMetrics, got, kmetricsCompareOptions...)
+		testutil.Debug(err, tt, expectedKMetrics, got)
+		assert.NoError(tt, err)
 	}, compareTimeout, compareTick)
 
 	t.Logf("Kafka Metrics checked successfully")

--- a/internal/testbed/integration/kafka/e2e_test.go
+++ b/internal/testbed/integration/kafka/e2e_test.go
@@ -302,7 +302,7 @@ func TestE2E_Kafka(t *testing.T) {
 		require.NotEmpty(tt, all)
 		got := all[len(all)-1]
 		err := pmetrictest.CompareMetrics(expectedKMetrics, got, kmetricsCompareOptions...)
-		testutil.Debug(err, tt, expectedKMetrics, got)
+		testutil.Debug(err, t, expectedKMetrics, got)
 		assert.NoError(tt, err)
 	}, compareTimeout, compareTick)
 

--- a/internal/testbed/integration/kafka/e2e_test.go
+++ b/internal/testbed/integration/kafka/e2e_test.go
@@ -205,7 +205,9 @@ func TestE2E_Kafka(t *testing.T) {
 		all := metricsConsumer.AllMetrics()
 		require.NotEmpty(tt, all)
 		got := all[len(all)-1]
-		assert.NoError(tt, pmetrictest.CompareMetrics(expectedMetrics, got, metricsCompareOptions...))
+		err := pmetrictest.CompareMetrics(expectedMetrics, got, metricsCompareOptions...)
+		testutil.Debug(err, t, expectedMetrics, got)
+		assert.NoError(tt, err)
 	}, compareTimeout, compareTick)
 
 	t.Logf("Metrics checked successfully")
@@ -302,7 +304,6 @@ func TestE2E_Kafka(t *testing.T) {
 		require.NotEmpty(tt, all)
 		got := all[len(all)-1]
 		err := pmetrictest.CompareMetrics(expectedKMetrics, got, kmetricsCompareOptions...)
-		testutil.Debug(err, t, expectedKMetrics, got)
 		assert.NoError(tt, err)
 	}, compareTimeout, compareTick)
 


### PR DESCRIPTION
Instead of always taking the last element, scan for any payload that matches and succeed as soon as one does