### PR TITLE
ASDY-26760 Add PS connectivity check workflow (research)

### DIFF
--- a/.github/workflows/ps-connectivity-check.yml
+++ b/.github/workflows/ps-connectivity-check.yml
@@ -1,0 +1,44 @@
+name: PS Connectivity Check (ASDY-26760)
+# Research workflow: verifies whether GitHub-hosted runners can reach
+# Dynatrace-internal endpoints (Promotion Service, initial ECR) that
+# would be required for a GitHub Actions-based BuildUnit release flow.
+# See: https://dt-rnd.atlassian.net/browse/ASDY-26760
+
+on:
+  workflow_dispatch:
+
+jobs:
+  connectivity-check:
+    name: Check PS + ECR reachability from GH-hosted runner
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Runner identity
+        run: |
+          echo "Runner OS    : $RUNNER_OS"
+          echo "Runner arch  : $RUNNER_ARCH"
+          echo "Runner name  : $RUNNER_NAME"
+          echo "Public IP    : $(curl -sf https://checkip.amazonaws.com || echo 'unavailable')"
+
+      - name: Promotion Service – Sandbox
+        run: |
+          echo "--- PS Sandbox (promotions.mcp-sandbox.internal.dynatracelabs.com) ---"
+          curl --connect-timeout 10 --max-time 15 -sv -o /dev/null \
+            https://promotions.mcp-sandbox.internal.dynatracelabs.com/api/buildunit-promotions/v1/buildunits \
+            2>&1 | grep -E "< HTTP|Connected to|Could not resolve|Connection refused|timed out|curl:" \
+            || echo "exit code: $? (6=DNS, 7=refused, 28=timeout)"
+
+      - name: Promotion Service – Production
+        run: |
+          echo "--- PS Prod (promotions.mcp.internal.dynatrace.com) ---"
+          curl --connect-timeout 10 --max-time 15 -sv -o /dev/null \
+            https://promotions.mcp.internal.dynatrace.com/api/buildunit-promotions/v1/buildunits \
+            2>&1 | grep -E "< HTTP|Connected to|Could not resolve|Connection refused|timed out|curl:" \
+            || echo "exit code: $? (6=DNS, 7=refused, 28=timeout)"
+
+      - name: Initial ECR (478983378254)
+        run: |
+          echo "--- Initial ECR ---"
+          curl --connect-timeout 10 --max-time 15 -sv -o /dev/null \
+            https://478983378254.dkr.ecr.us-east-1.amazonaws.com/v2/ \
+            2>&1 | grep -E "< HTTP|Connected to|Could not resolve|Connection refused|timed out|curl:" \
+            || echo "exit code: $? (6=DNS, 7=refused, 28=timeout)"


### PR DESCRIPTION
## Summary

This PR adds a `workflow_dispatch`-triggered workflow to verify whether GitHub-hosted runners (`ubuntu-24.04`) can reach Dynatrace-internal endpoints required for a GitHub Actions-based BuildUnit release flow.

This is research work for [ASDY-26760](https://dt-rnd.atlassian.net/browse/ASDY-26760) — identifying blockers for releasing OTel components via Promotion Service from GitHub.

## What it tests

The workflow probes three endpoints from a stock GitHub-hosted runner:

| Endpoint | What a result tells us |
|---|---|
| PS Sandbox (`promotions.mcp-sandbox.internal.dynatracelabs.com`) | HTTP response = reachable; DNS error / timeout = blocked from GH runners |
| PS Production (`promotions.mcp.internal.dynatrace.com`) | Same |
| Initial ECR (`478983378254.dkr.ecr.us-east-1.amazonaws.com`) | 401 from AWS auth = reachable; timeout = blocked |

## Expected result

Both PS endpoints are expected to **fail** (DNS resolution error, exit code 6) — they are internal names not resolvable from GitHub infrastructure. The initial ECR is expected to **succeed** (401 from AWS) as it is a public AWS endpoint.

If PS is confirmed unreachable, the DACI must decide on runner strategy: switch to self-hosted runners with internal network access, or trigger an internal Jenkins job from GH for the PS registration step.

## How to run

Go to **Actions → PS Connectivity Check (ASDY-26760) → Run workflow**.

> ⚠️ AI-assisted change (Claude Code)


[ASDY-26760]: https://dt-rnd.atlassian.net/browse/ASDY-26760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ