### PR TITLE
[chore] add RPM-specific postinstall script

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -95,6 +95,8 @@ nfpms:
       rpm:
         dependencies:
           - /bin/sh
+        scripts:
+          postinstall: internal/release/postinstall-rpm.sh
     maintainer: "Dynatrace LLC <opensource@dynatrace.com>"
     vendor: "Dynatrace LLC"
     description: Dynatrace distribution of the OpenTelemetry Collector

--- a/internal/release/postinstall-rpm.sh
+++ b/internal/release/postinstall-rpm.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Copyright The OpenTelemetry Authors
+# Copyright Dynatrace LLC
+# SPDX-License-Identifier: Apache-2.0
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload
+    systemctl try-restart dynatrace-otel-collector.service
+fi


### PR DESCRIPTION
## Summary

Backport of [open-telemetry/opentelemetry-collector-releases#1335](https://github.com/open-telemetry/opentelemetry-collector-releases/pull/1335).

On RPM, the generic `postinstall.sh` runs `systemctl enable` + `restart`, which starts the service on fresh install even without a config file present. The RPM-specific override uses `try-restart` instead — it only restarts the service if it's already running (i.e. upgrades), leaving fresh installs untouched.

**Changes:**
- Add `internal/release/postinstall-rpm.sh` with RPM-safe `daemon-reload` + `try-restart`
- Wire it into `.goreleaser.yaml` under `nfpms.overrides.rpm.scripts.postinstall`