### PR TITLE
fix: escape the word boundary in the IPv4 redaction example

### DIFF
--- a/.chloggen/redaction-ipv4-example.yaml
+++ b/.chloggen/redaction-ipv4-example.yaml
@@ -1,0 +1,18 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+component: redaction.yaml
+
+note: Escape the word boundary in the IPv4 pattern of the redaction config example so that it matches addresses again.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [1110]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  In a double-quoted YAML scalar `\b` is the backspace escape, so the pattern
+  required a literal 0x08 byte and never matched an IPv4 address.

--- a/config_examples/redaction.yaml
+++ b/config_examples/redaction.yaml
@@ -18,7 +18,7 @@ processors:
     blocked_values:
       - "4[0-9]{12}(?:[0-9]{3})?" ## Visa credit card number
       - "(5[1-5][0-9]{14})"       ## MasterCard number
-      - "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\b){4}$" ## IPv4 addresses
+      - "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$" ## IPv4 addresses
       - "^[\\w\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$" ## email addresses (simplified example)
     summary: info
 


### PR DESCRIPTION
in `config_examples/redaction.yaml` the IPv4 entry uses a single-backslash `\b`:

```yaml
- "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\b){4}$" ## IPv4 addresses
```

inside a double-quoted YAML scalar `\b` is the backspace escape, so the pattern that reaches the redaction processor ends with a literal `0x08` byte instead of a word boundary. it can never match an address. every other escape in the same list is already doubled, so this one looks like a slip rather than intent

parsing the file with yaml.v3 and compiling the result, the pattern matches none of `192.168.1.100`, `10.0.0.1`, `8.8.8.8`, `255.255.255.255`, `1.2.3.4`, while the three neighbouring patterns work. with the fix it matches all five

the same IPv4 regex lives in `internal/testcommon/oteltest/sinks.go:37` without the `\b` and behaves correctly there

someone copying this example to strip IPs before shipping telemetry gets a config that looks right and redacts nothing. the shipped `allow_all_keys: false` limits how much that bites in practice, but the example is still wrong

## changes

double the backslash so the word boundary survives YAML parsing, plus a changelog entry