### PR TITLE
[chore] Wait for at least one trace in the GenAI normalizer E2E test

### DIFF
--- a/internal/testbed/integration/genainormalizer/e2e_test.go
+++ b/internal/testbed/integration/genainormalizer/e2e_test.go
@@ -130,7 +130,7 @@ func TestE2E_GenAINormalizerProcessor(t *testing.T) {
 	_, err = traceClient.Export(context.Background(), ptraceotlp.NewExportRequestFromTraces(buildTestTraces()))
 	require.NoError(t, err)
 
-	oteltest.WaitForTraces(t, 0, tracesConsumer)
+	oteltest.WaitForTraces(t, 1, tracesConsumer)
 
 	traceCompareOptions := []ptracetest.CompareTracesOption{
 		ptracetest.IgnoreStartTimestamp(),


### PR DESCRIPTION
Follow up to https://github.com/Dynatrace/dynatrace-otel-collector/pull/1122.