### PR TITLE
[chore] docs: remove outdated disclaimer for filestorageextension

### DIFF
--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -6,7 +6,6 @@ on:
     paths-ignore:
       - "CHANGELOG.md"
       - "docs/**"
-      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The following components are included in the distribution:
 * [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension)
 * [zpagesextension](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/zpagesextension)
 * [k8sleaderelectorextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/k8sleaderelector)
-* [filestorageextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage) [^1]
+* [filestorageextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage)
 
 ### Connectors
 


### PR DESCRIPTION
**filestorageextension** component is in beta but still had a disclaimer referring to 'alpha' stability in the README.md