### PR TITLE
[chore] Add /var/lib/dynatrace-otel-collector directory to linux packages

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -82,6 +82,12 @@ nfpms:
         dst: /lib/systemd/system/dynatrace-otel-collector.service
       - src: internal/release/dynatrace-otel-collector.conf
         dst: /etc/dynatrace-otel-collector/dynatrace-otel-collector.conf
+      - dst: /var/lib/dynatrace-otel-collector
+        type: dir
+        file_info:
+          owner: otel
+          group: otel
+          mode: 0o750
     umask: 0o002
     scripts:
       preinstall: internal/release/preinstall.sh


### PR DESCRIPTION
Aligns with upstream otelcol-contrib which creates a persistent state directory owned by the collector user, needed for the filestorage extension.