### PR TITLE
[chore] fix: re-trigger changelog check on PR title edits

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,7 @@ name: 'Changelog'
 
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled, edited]
     branches:
       - main
 


### PR DESCRIPTION
The workflow's if-condition skips the job when the title contains "[chore]", but editing the title didn't retrigger the workflow since "edited" wasn't in the pull_request types, leaving the check stuck.