### PR TITLE
[chore] docs: remove notice of loadbalancing exporter being in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,10 @@ The following components are included in the distribution:
 ### Exporters
 
 * [debugexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter)
-* [load_balancing exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter) [^2]
+* [load_balancing exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter) [^1]
 * [otlpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter)
 * [otlphttpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter)
 * [kafkaexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter)
-
-[^2]: The load balancing exporter is [**in development**](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#development) for the metrics signal. There may be bugs or performance issues, and using this component for metrics in production is discouraged. Bugs, performance issues, and feature requests related to metrics should be reported to the upstream repository.
 
 ### Extensions
 


### PR DESCRIPTION
Loadbalancing exporter has been promoted to alpha for metrics, thus we don't need the notice of "development" stability for the component anymore.